### PR TITLE
Update Nokia_LCD.cpp

### DIFF
--- a/src/Nokia_LCD.cpp
+++ b/src/Nokia_LCD.cpp
@@ -263,11 +263,27 @@ bool Nokia_LCD::print(unsigned long number) {
     return print(number_as_string);
 }
 
+//----
+// 27-Nov-2020 - Correction of issue #6 - Error in print(float) function
+//
+// In previous release, numbers like 1.0123 or 1.00123 were printed 1.123,
+// having the 0s next to the coma skipped.
+//----
 bool Nokia_LCD::print(double number, unsigned short decimals) {
     double integral = 0;
     long fractional = pow(10.0, decimals) * modf(number, &integral);
+    bool out_of_bounds = false;
 
-    return print(static_cast<long>(number)) || print(".") || print(fractional);
+	out_of_bounds = print(static_cast<long>(number)) || out_of_bounds;
+	out_of_bounds = print(".") || out_of_bounds;
+	
+	for(int d=decimals-1 ; 0<=d; d-- ) {
+		int num = fractional/pow(10, d);
+		if (num) break; //print only leading 0s
+		out_of_bounds = print(num) || out_of_bounds;
+	}
+		
+    return (print(fractional) || out_of_bounds);
 }
 
 bool Nokia_LCD::println(int number) {


### PR DESCRIPTION
Correction of issue #6 - Error in print(float) function
numbers like 1.0123 or 1.00123 were printed 1.123, having the 0s next to the coma all skipped.